### PR TITLE
Add vPC & LACP NX-OS feature checks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ dist/
 
 # Editors
 .idea/
+.vscode/

--- a/docs/source/nos/cisco_nxos.rst
+++ b/docs/source/nos/cisco_nxos.rst
@@ -56,6 +56,16 @@ Check if the vPC feature is actually used, should it be enabled.
 
 * Hygiene
 
+NXOS106
+-------
+
+Check if the LACP feature is actually used, should it be enabled.
+
+**Tags**
+
+
+* Hygiene
+
 VAR101
 ------
 

--- a/docs/source/nos/cisco_nxos.rst
+++ b/docs/source/nos/cisco_nxos.rst
@@ -46,6 +46,16 @@ Check if any bogus autonomous system is used in the configuration.
 
 * Hygiene
 
+NXOS105
+-------
+
+Check if the vPC feature is actually used, should it be enabled.
+
+**Tags**
+
+
+* Hygiene
+
 VAR101
 ------
 

--- a/netlint/checks/cisco_nxos/__init__.py
+++ b/netlint/checks/cisco_nxos/__init__.py
@@ -77,3 +77,19 @@ def check_bogus_as(config: typing.List[str]) -> typing.Optional[CheckResult]:
         return CheckResult(text="Bogus AS number in use", lines=bad_lines)
     else:
         return None
+
+
+@Checker.register(apply_to=[NOS.CISCO_NXOS], name="NXOS105", tags={Tag.HYGIENE})
+def check_vpc_feature_enabled_and_used(
+    config: typing.List[str],
+) -> typing.Optional[CheckResult]:
+    """Check if the vPC feature is actually used if it is enabled."""
+    parsed_config = CiscoConfParse(config)
+    feature_enabled = parsed_config.find_lines(r"^feature vpc")
+    feature_configured = parsed_config.find_lines(r"^vpc domain")
+    if feature_enabled and not feature_configured:
+        return CheckResult(
+            text="vPC feature enabled but never used",
+            lines=feature_enabled + feature_configured,
+        )
+    return None

--- a/netlint/checks/cisco_nxos/__init__.py
+++ b/netlint/checks/cisco_nxos/__init__.py
@@ -93,3 +93,21 @@ def check_vpc_feature_enabled_and_used(
             lines=feature_enabled + feature_configured,
         )
     return None
+
+
+@Checker.register(apply_to=[NOS.CISCO_NXOS], name="NXOS106", tags={Tag.HYGIENE})
+def check_lacp_feature_enabled_and_used(
+    config: typing.List[str],
+) -> typing.Optional[CheckResult]:
+    """Check if the LACP feature is actually used if it is enabled."""
+    parsed_config = CiscoConfParse(config)
+    feature_enabled = parsed_config.find_lines(r"^feature lacp")
+    feature_configured = parsed_config.find_lines(
+        r"^\s+channel-group \d+ mode active|passive"
+    )
+    if feature_enabled and not feature_configured:
+        return CheckResult(
+            text="LACP feature enabled but never used",
+            lines=feature_enabled + feature_configured,
+        )
+    return None

--- a/tests/configurations/cisco_nxos/check_lacp_feature_enabled_and_used_faulty-0.conf
+++ b/tests/configurations/cisco_nxos/check_lacp_feature_enabled_and_used_faulty-0.conf
@@ -1,0 +1,10 @@
+feature lacp
+
+interface Ethernet1/1
+  switchport
+  switchport mode trunk
+  channel-group 1
+
+interface port-channel1
+  switchport
+  switchport mode trunk

--- a/tests/configurations/cisco_nxos/check_lacp_feature_enabled_and_used_faulty-1.conf
+++ b/tests/configurations/cisco_nxos/check_lacp_feature_enabled_and_used_faulty-1.conf
@@ -1,0 +1,10 @@
+feature lacp
+
+interface Ethernet1/1
+  switchport
+  switchport mode trunk
+
+interface Ethernet1/2
+  switchport
+  switchport mode access
+  switchport access vlan 10

--- a/tests/configurations/cisco_nxos/check_lacp_feature_enabled_and_used_good-0.conf
+++ b/tests/configurations/cisco_nxos/check_lacp_feature_enabled_and_used_good-0.conf
@@ -1,0 +1,10 @@
+feature lacp
+
+interface Ethernet1/1
+  switchport
+  switchport mode trunk
+  channel-group 1 mode active
+
+interface port-channel1
+  switchport
+  switchport mode trunk

--- a/tests/configurations/cisco_nxos/check_lacp_feature_enabled_and_used_good-1.conf
+++ b/tests/configurations/cisco_nxos/check_lacp_feature_enabled_and_used_good-1.conf
@@ -1,0 +1,10 @@
+feature lacp
+
+interface Ethernet1/1
+  switchport
+  switchport mode trunk
+  channel-group 1 mode passive
+
+interface port-channel1
+  switchport
+  switchport mode trunk

--- a/tests/configurations/cisco_nxos/check_vpc_feature_enabled_and_used_faulty-0.conf
+++ b/tests/configurations/cisco_nxos/check_vpc_feature_enabled_and_used_faulty-0.conf
@@ -1,0 +1,1 @@
+feature vpc

--- a/tests/configurations/cisco_nxos/check_vpc_feature_enabled_and_used_good-0.conf
+++ b/tests/configurations/cisco_nxos/check_vpc_feature_enabled_and_used_good-0.conf
@@ -1,0 +1,10 @@
+feature vpc
+feature eigrp
+
+vpc domain 1
+  peer-keepalive destination 1.2.3.4 source 5.6.7.8 vrf management
+  peer-gateway
+  layer3 peer-router
+
+router eigrp UNDERLAY
+  router-id 192.0.2.100

--- a/tests/configurations/cisco_nxos/check_vpc_feature_enabled_and_used_good-1.conf
+++ b/tests/configurations/cisco_nxos/check_vpc_feature_enabled_and_used_good-1.conf
@@ -1,0 +1,4 @@
+feature eigrp
+
+router eigrp UNDERLAY
+  router-id 192.0.2.100


### PR DESCRIPTION
Add NX-OS checks for the vPC and LACP features to verify that if both features are enabled, they are properly configured. These are NXOS105 and NXOS106, respectively.

Also added VSCode folders to the .gitignore so that VSCode users do not accidentally commit aspects of their environment to the repository.

Documentation for NXOS105 and NXOS106 have been updated as well.